### PR TITLE
Revert Old Screenoff-FOD

### DIFF
--- a/res/values/zenx_arrays.xml
+++ b/res/values/zenx_arrays.xml
@@ -1546,14 +1546,12 @@
     <string-array name="volume_panel_entries">
         <item>@string/volume_panel_aosp</item>
         <item>@string/volume_panel_compat</item>
-        <item>@string/volume_panel_oreo</item>
         <item>@string/volume_panel_tiled</item>
     </string-array>
 
     <string-array name="volume_panel_values" translatable="false">
         <item>@string/volume_panel_aosp_val</item>
         <item>@string/volume_panel_compat_val</item>
-        <item>@string/volume_panel_oreo_val</item>
         <item>@string/volume_panel_tiled_val</item>
     </string-array>
 

--- a/res/values/zenx_strings.xml
+++ b/res/values/zenx_strings.xml
@@ -1168,7 +1168,7 @@
 
      <!-- Ambient visualizer -->
     <string name="ambient_visualizer_title">Show on Ambient Display</string>
-    <string name="ambient_visualizer_summary">Display the visualizer bars on ambient display</string>
+    <string name="ambient_visualizer_summary">Display the visualizer bars on ambient display (Reboot SystemUI to apply)</string>
     <!-- Media heads up -->
     <string name="show_media_heads_up_title">Media heads up</string>
     <string name="show_media_heads_up_summary">Show heads up notification when a new track is played</string>
@@ -1551,6 +1551,8 @@
     <string name="listview_overshoot_interpolator">Overshoot</string>
     <string name="listview_anticipate_overshoot_interpolator">Anticipate and overshoot</string>
     <string name="listview_bounce_interpolator">Bounce</string>
+        <!-- Show Visualizer in QSPanel -->
+    <string name="synthos_visualizer_qspanel_title">Show Music Visualizer in QS Panel</string>
 
      <!-- RGB Picker -->
     <string name="rgb_accent_picker_title">RGB accent picker</string>

--- a/res/values/zenx_strings.xml
+++ b/res/values/zenx_strings.xml
@@ -1277,6 +1277,9 @@
     <string name="summary_dashboard_suggestions_disabled">Dashboard suggestions are disabled</string>
 
     <string name="custom_doze_settings">Custom Doze</string>
+    <!-- Screen off FOD -->
+    <string name="screen_off_fod_title">Screen off FOD</string>
+    <string name="screen_off_fod_summary">Use fingerprint reader also when the screen is off</string>
 
     <!-- FOD animations -->
     <string name="fod_recog_animation">Recognizing animation</string>
@@ -1296,11 +1299,6 @@
     <string name="fod_recog_animation_pureview_future">Future</string>
     <string name="fod_recog_animation_pureview_molecular">Molecular</string>
 
-    <!-- Screen off FOD -->
-    <string name="screen_off_fod_title">Screen off FOD</string>
-    <string name="screen_off_fod_summary">Use fingerprint reader also when the screen is off</string>
-    <string name="screen_off_fod_icon_title">Show icon</string>
-    <string name="screen_off_fod_icon_summary">Show fingerprint icon when the screen is off</string>
 
     <!-- Status Bar Ticker -->
     <string name="ticker_screen_title">Ticker</string>

--- a/res/values/zenx_strings.xml
+++ b/res/values/zenx_strings.xml
@@ -1603,12 +1603,10 @@
     <string name="volume_panel">Volume Panel Style</string>
     <string name="volume_panel_aosp">AOSP</string>
     <string name="volume_panel_compat">Compact</string>
-    <string name="volume_panel_oreo">Oreo</string>
     <string name="volume_panel_tiled">Tiled</string>
     <!--  Volume Panel Plugin Values   -->
     <string name="volume_panel_aosp_val" translatable="false">co.potatoproject.plugin.volume.aosp</string>
     <string name="volume_panel_compat_val" translatable="false">co.potatoproject.plugin.volume.compact</string>
-    <string name="volume_panel_oreo_val" translatable="false">co.potatoproject.plugin.volume.oreo</string>
     <string name="volume_panel_tiled_val" translatable="false">co.potatoproject.plugin.volume.tiled</string>
 
         <!-- QQS brightness slider -->

--- a/res/xml/zen_hub_lockscreen.xml
+++ b/res/xml/zen_hub_lockscreen.xml
@@ -177,18 +177,7 @@
             android:defaultValue="0"
             android:dependency="fod_recognizing_animation" />
 
-        <com.zenx.support.preferences.SwitchPreference
-            android:key="screen_off_fod"
-            android:title="@string/screen_off_fod_title"
-            android:summary="@string/screen_off_fod_summary"
-            android:defaultValue="false" />
 
-        <com.zenx.support.preferences.SystemSettingSwitchPreference
-            android:key="screen_off_fod_icon"
-            android:title="@string/screen_off_fod_icon_title"
-            android:summary="@string/screen_off_fod_icon_summary"
-            android:defaultValue="true"
-            android:dependency="screen_off_fod" />
 
     </PreferenceCategory>
 

--- a/res/xml/zen_hub_quicksettings.xml
+++ b/res/xml/zen_hub_quicksettings.xml
@@ -122,6 +122,13 @@
             android:fragment="com.zenx.zen.hub.fragments.statusbarquicksettings.tabs.submodules.QsBlur"
             android:defaultValue="false" />
 
+                <!-- Visualizer QSPanel -->
+        <com.zenx.support.preferences.SystemSettingSwitchPreference
+            android:key="synthos_visualizer_qspanel"
+            android:title="@string/synthos_visualizer_qspanel_title"
+            android:defaultValue="true" />
+
+
         <ListPreference
             android:key="qs_background_style"
             android:title="@string/qs_background_style_title"

--- a/src/com/zenx/zen/hub/fragments/lockscreenambient/tabs/LockScreen.java
+++ b/src/com/zenx/zen/hub/fragments/lockscreenambient/tabs/LockScreen.java
@@ -30,6 +30,10 @@ import android.os.Bundle;
 import android.provider.Settings;
 import androidx.preference.*;
 import android.content.pm.PackageManager;
+import androidx.preference.Preference;
+import androidx.preference.ListPreference;
+import androidx.preference.SwitchPreference;
+import androidx.preference.PreferenceScreen;
 
 import com.android.internal.custom.app.LineageContextConstants;
 import com.android.internal.logging.nano.MetricsProto;
@@ -43,7 +47,6 @@ import com.zenx.support.preferences.SecureSettingMasterSwitchPreference;
 import com.zenx.support.preferences.CustomSeekBarPreference;
 import com.zenx.support.colorpicker.ColorPickerPreference;
 import com.zenx.support.preferences.SystemSettingSwitchPreference;
-import com.zenx.support.preferences.SwitchPreference;
 
 public class LockScreen extends SettingsPreferenceFragment implements
         Preference.OnPreferenceChangeListener {
@@ -51,10 +54,9 @@ public class LockScreen extends SettingsPreferenceFragment implements
     private static final String LOCKSCREEN_VISUALIZER_ENABLED = "lockscreen_visualizer_enabled";
     private static final String SYSUI_KEYGUARD_SHOW_BATTERY_BAR = "sysui_keyguard_show_battery_bar";
     private static final String FOD_ANIMATION_PREF = "fod_recognizing_animation";
-    private static final String KEY_SCREEN_OFF_FOD = "screen_off_fod";
-    private static final String KEY_SCREEN_OFF_FOD_ICON = "screen_off_fod_icon";
     private static final String FOD_ICON_PICKER_CATEGORY = "fod_icon_picker_category";
     private static final String FOD_CATEGORY = "fod_category";
+    private static final String KEY_SCREEN_OFF_FOD = "screen_off_fod";
 
     private static final int DEFAULT_COLOR = 0xffffffff;
 
@@ -62,10 +64,9 @@ public class LockScreen extends SettingsPreferenceFragment implements
     private CustomSeekBarPreference mMaxKeyguardNotifConfig;
     private SystemSettingMasterSwitchPreference mLsBatteryBar;
     private SystemSettingSwitchPreference mFODAnimationEnabled;
-    private SwitchPreference mScreenOffFOD;
-    private SystemSettingSwitchPreference mScreenOffFODIcon;
     private Preference mFODIconPicker;
     private PreferenceCategory mFODCategory;
+    private SwitchPreference mScreenOffFOD;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -86,21 +87,15 @@ public class LockScreen extends SettingsPreferenceFragment implements
         PackageManager packageManager = getPackageManager();
 
         mFODAnimationEnabled = (SystemSettingSwitchPreference) findPreference(FOD_ANIMATION_PREF);
+        if (!packageManager.hasSystemFeature(LineageContextConstants.Features.FOD)) {
+            mFODAnimationEnabled.setVisible(false);
+        }
 
-        boolean mScreenOffFODValue = Settings.System.getInt(getActivity().getContentResolver(),
-                Settings.System.SCREEN_OFF_FOD, 0) != 0;
-
-        mScreenOffFOD = (SwitchPreference) findPreference(KEY_SCREEN_OFF_FOD);
-        mScreenOffFOD.setChecked(mScreenOffFODValue);
-        mScreenOffFOD.setOnPreferenceChangeListener(this);
 
         mFODCategory = (PreferenceCategory) findPreference(FOD_CATEGORY);
-        mScreenOffFODIcon = (SystemSettingSwitchPreference) findPreference(KEY_SCREEN_OFF_FOD_ICON);
 
         if (!packageManager.hasSystemFeature(LineageContextConstants.Features.FOD)) {
             mFODAnimationEnabled.setVisible(false);
-            mScreenOffFOD.setVisible(false);
-            mScreenOffFODIcon.setVisible(false);
             prefSet.removePreference(mFODCategory);
         }
 
@@ -133,11 +128,6 @@ public class LockScreen extends SettingsPreferenceFragment implements
             boolean value = (Boolean) newValue;
             Settings.System.putInt(getContentResolver(),
 		            SYSUI_KEYGUARD_SHOW_BATTERY_BAR, value ? 1 : 0);
-            return true;
-        } else if (preference == mScreenOffFOD) {
-            int mScreenOffFODValue = (Boolean) newValue ? 1 : 0;
-            Settings.System.putInt(getContentResolver(), Settings.System.SCREEN_OFF_FOD, mScreenOffFODValue);
-            Settings.Secure.putInt(getContentResolver(), Settings.Secure.DOZE_ALWAYS_ON, mScreenOffFODValue);
             return true;
         }
         return false;


### PR DESCRIPTION
Revert "Screen off FOD [3/3]"

This reverts commit 617ebccb843d274379d518c78c617e018bec45c4.

Revert "Show icon when Screen Off FOD is enabled [2/2]"

This reverts commit b393ca01ee5a542f608dd06cf9216a9e78b6abac.

Revert "Conditionally hide the Screen off FOD preference"

This reverts commit aad0adc2d7a76bdb4ee9107f78eb365688ecc197.

ZenHub: Old Screen-Off FOD Clean-Up